### PR TITLE
Boolean Values

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -69,6 +69,8 @@ func (l *Lexer) NextToken() Token {
 			return tok
 		} else if isValidString(tok.Literal) {
 			tok.Type = String
+		} else if isValidBool(tok.Literal) {
+			tok.Type = Bool
 		} else if isValidSymbol(tok.Literal) {
 			tok.Type = Symbol
 			return tok
@@ -109,6 +111,10 @@ func isInteger(expr string) bool {
 
 func isValidSymbol(expr string) bool {
 	return validateRegex(expr, `^[a-zA-Z0-9+\-*/^]+$`)
+}
+
+func isValidBool(expr string) bool {
+	return validateRegex(expr, `^(true|false)$`)
 }
 
 func isValidChar(ch byte) bool {

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -69,13 +69,16 @@ func (l *Lexer) NextToken() Token {
 			return tok
 		} else if isValidString(tok.Literal) {
 			tok.Type = String
+			return tok
 		} else if isValidBool(tok.Literal) {
 			tok.Type = Bool
+			return tok
 		} else if isValidSymbol(tok.Literal) {
 			tok.Type = Symbol
 			return tok
 		} else {
 			tok.Type = IllegalToken
+			return tok
 		}
 	}
 

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -193,6 +193,28 @@ func TestStringDeclaration(t *testing.T) {
 	}
 }
 
+func TestValidateListOfStrings(t *testing.T) {
+	input := `("a" "b")`
+	tests := []struct {
+		expectedType    TokenType
+		expectedLiteral string
+	}{
+		{LParen, "("},
+		{String, `"a"`},
+		{String, `"b"`},
+		{RParen, ")"},
+	}
+
+	l := NewLexer(input)
+	for _, tt := range tests {
+		tok := l.NextToken()
+
+		assert.Equal(t, tt.expectedType, tok.Type, fmt.Sprintf("Token literal: %q", tok.Literal))
+		assert.Equal(t, tt.expectedLiteral, tok.Literal)
+	}
+
+}
+
 func TestValidateString(t *testing.T) {
 	expr := `ab'cd`
 	result := isValidSymbol(expr)

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -147,7 +147,7 @@ func TestFloatDeclaration(t *testing.T) {
 }
 
 func TestPlusExprAreRecognized(t *testing.T) {
-	input := `(+ 1 2)`
+	input := `(+ 1 true)`
 
 	tests := []struct {
 		expectedType    TokenType
@@ -156,7 +156,7 @@ func TestPlusExprAreRecognized(t *testing.T) {
 		{LParen, "("},
 		{Symbol, "+"},
 		{Int, "1"},
-		{Int, "2"},
+		{Bool, "true"},
 		{RParen, ")"},
 	}
 

--- a/lexer/token.go
+++ b/lexer/token.go
@@ -12,6 +12,7 @@ const (
 	String
 	Int
 	Float
+	Bool
 	EOF
 )
 

--- a/parser/ast/boolean.go
+++ b/parser/ast/boolean.go
@@ -1,0 +1,30 @@
+package ast
+
+import (
+	"strconv"
+
+	lx "github.com/tamercuba/golisp/lexer"
+)
+
+type Boolean struct {
+	token lx.Token
+	value bool
+}
+
+func NewBoolean(token lx.Token) *Boolean {
+	value, _ := strconv.ParseBool(token.Literal)
+	// Error is unreachable because Lexer has already validated
+	return &Boolean{token, value}
+}
+
+func (b *Boolean) GetToken() lx.Token {
+	return b.token
+}
+
+func (b Boolean) String() string {
+	return b.token.Literal
+}
+
+func (b *Boolean) GetValue() any {
+	return b.value
+}

--- a/parser/ast/nodes_test.go
+++ b/parser/ast/nodes_test.go
@@ -89,3 +89,14 @@ func TestFunctionDeclaration(t *testing.T) {
 	assert.Equal(t, "(", l.GetValue())
 	assert.Equal(t, "(", l.GetToken().Literal)
 }
+
+func TestBooleanDeclaration(t *testing.T) {
+	var tok lx.Token
+	tok.Literal = "true"
+	tok.Type = lx.Bool
+	b := NewBoolean(tok)
+
+	assert.Equal(t, "true", fmt.Sprintf("%v", b))
+	assert.Equal(t, true, b.GetValue())
+	assert.Equal(t, "true", b.GetToken().Literal)
+}

--- a/parser/defun.go
+++ b/parser/defun.go
@@ -35,10 +35,6 @@ func (p *Parser) parseDefun() *ast.FunctionDeclaration {
 	p.nextToken()
 	body := p.parseList()
 
-	if p.peekToken.Type != lx.RParen {
-		panic(fmt.Sprintf("%v Syntax Error. Too many arguments", p.peekToken.Pos))
-	}
-
 	return ast.NewFunctionDeclaration(firstToken, funcName, funcArgs, body)
 }
 

--- a/parser/let.go
+++ b/parser/let.go
@@ -13,7 +13,7 @@ func (p *Parser) parseLet() *ast.LetDeclaration {
 	// (let x 10)
 
 	if p.peekToken.Type != lx.Symbol {
-		panic(fmt.Sprintf("%q Type Error. %q isnt a valid binding name", p.peekToken.Pos, p.peekToken))
+		panic(fmt.Sprintf("%v Type Error. %v isnt a valid binding name", p.peekToken.Pos, p.peekToken))
 	}
 	p.nextToken()
 	bindingName := p.parseSymbol()
@@ -32,6 +32,8 @@ func (p *Parser) parseLet() *ast.LetDeclaration {
 		bindingValue = p.parseFloat()
 	case lx.String:
 		bindingValue = p.parseString()
+	case lx.Bool:
+		bindingValue = p.parseBoolean()
 	default:
 		panic(fmt.Sprintf("%q Type Error. %q isnt a valid binding value", p.peekToken.Pos, p.peekToken))
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -49,9 +49,6 @@ func ParseProgram(l *lx.Lexer) (*ast.Program, error) {
 		case lx.String:
 			n := p.parseString()
 			program.ListStatements = append(program.ListStatements, n)
-		case lx.Symbol:
-			n := p.parseSymbol()
-			program.ListStatements = append(program.ListStatements, n)
 		case lx.Bool:
 			n := p.parseBoolean()
 			program.ListStatements = append(program.ListStatements, n)
@@ -65,10 +62,6 @@ func ParseProgram(l *lx.Lexer) (*ast.Program, error) {
 
 func (p *Parser) parseList() ast.Node {
 	// Expect curToken.Type == LParen
-	if p.curToken.Type != lx.LParen {
-		panic(fmt.Sprintf("[%v] Invalid syntax, %q given, '(' expected", p.curToken.Pos, p.curToken))
-	}
-
 	if p.peekToken.Type == lx.Symbol {
 		result := p.parseNextSymbol()
 		if result != nil {
@@ -101,7 +94,7 @@ func (p *Parser) parseList() ast.Node {
 		case lx.Bool:
 			list.Append(p.parseBoolean())
 		case lx.EOF:
-			panic("Unbalanced parentheses: EOF reached while parsing a list. [parseList]")
+			panic(fmt.Sprintf("%v( not closed, expect ).", list.GetToken().Pos))
 		default:
 			panic(fmt.Sprintf("Unexpected token in list: %+v", p.curToken))
 		}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -244,3 +244,48 @@ func TestLetDeclarationWithInvalidName(t *testing.T) {
 		ParseProgram(l)
 	})
 }
+
+func TestListWithBooleanValues(t *testing.T) {
+	input := `(true false)`
+	lexer := lexer.NewLexer(input)
+	result, err := ParseProgram(lexer)
+
+	assert.Nil(t, err)
+	assert.IsType(t, &ast.Program{}, result)
+	assert.Equal(t, 1, len(result.ListStatements))
+
+	s := result.ListStatements[0]
+
+	switch l := s.(type) {
+	case *ast.ListExpression:
+		assert.Equal(t, 2, l.Size)
+		assert.Equal(t, true, l.Head.LNode.GetValue())
+		assert.Equal(t, false, l.Head.Next.LNode.GetValue())
+	default:
+		assert.Fail(t, fmt.Sprintf("Invalid type: %+v", l))
+	}
+
+}
+
+func TestLetWithBooleanValue(t *testing.T) {
+	input := `(let x true)`
+	l := lexer.NewLexer(input)
+	r, err := ParseProgram(l)
+
+	assert.Equal(t, 1, len(r.ListStatements))
+	s := r.ListStatements[0]
+
+	assert.Nil(t, err)
+	assert.IsType(t, &ast.LetDeclaration{}, s)
+	assert.Equal(t, "let", s.GetToken().Literal)
+
+	switch v := s.(type) {
+	case *ast.LetDeclaration:
+		assert.Equal(t, "x", v.Name.String())
+		assert.Equal(t, true, v.Value.GetValue())
+		assert.Equal(t, "(let x true)", fmt.Sprintf("%v", v))
+	default:
+		assert.Fail(t, fmt.Sprintf("Invalid type: %+v", v))
+	}
+
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -210,7 +210,6 @@ func TestLetWithStringValue(t *testing.T) {
 	default:
 		assert.Fail(t, fmt.Sprintf("Invalid type: %+v", v))
 	}
-
 }
 
 func TestDefunDeclarationNode(t *testing.T) {
@@ -234,7 +233,6 @@ func TestDefunDeclarationNode(t *testing.T) {
 	default:
 		assert.Fail(t, fmt.Sprintf("Invalid type: %+v", v))
 	}
-
 }
 
 func TestLetDeclarationWithInvalidName(t *testing.T) {
@@ -264,7 +262,6 @@ func TestListWithBooleanValues(t *testing.T) {
 	default:
 		assert.Fail(t, fmt.Sprintf("Invalid type: %+v", l))
 	}
-
 }
 
 func TestLetWithBooleanValue(t *testing.T) {
@@ -287,5 +284,62 @@ func TestLetWithBooleanValue(t *testing.T) {
 	default:
 		assert.Fail(t, fmt.Sprintf("Invalid type: %+v", v))
 	}
+}
 
+func TestIntAloneInput(t *testing.T) {
+	input := `1`
+	l := lexer.NewLexer(input)
+	r, err := ParseProgram(l)
+
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(r.ListStatements))
+
+	s := r.ListStatements[0]
+
+	assert.Equal(t, "1", s.String())
+	assert.Equal(t, int32(1), s.GetValue())
+	assert.IsType(t, &ast.IntLiteral{}, s)
+}
+
+func TestFloatAloneInput(t *testing.T) {
+	input := `1.2`
+	l := lexer.NewLexer(input)
+	r, err := ParseProgram(l)
+
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(r.ListStatements))
+
+	s := r.ListStatements[0]
+
+	assert.Equal(t, "1.200000f", s.String())
+	assert.Equal(t, 1.2, s.GetValue())
+	assert.IsType(t, &ast.FloatLiteral{}, s)
+}
+
+func TestBooleanAlone(t *testing.T) {
+	input := `true`
+	l := lexer.NewLexer(input)
+	r, err := ParseProgram(l)
+
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(r.ListStatements))
+
+	s := r.ListStatements[0]
+
+	assert.Equal(t, "true", s.String())
+	assert.Equal(t, true, s.GetValue())
+	assert.IsType(t, &ast.Boolean{}, s)
+}
+
+func TestUnbalancedList(t *testing.T) {
+	input := `(1 2`
+	l := lexer.NewLexer(input)
+
+	defer func() {
+		if r := recover(); r != nil {
+			expectedMessage := "0:0 ( not closed, expect )."
+			assert.Equal(t, expectedMessage, r)
+		}
+	}()
+	ParseProgram(l)
 }


### PR DESCRIPTION
## 🔨 Describe your changes

- Added support for the `bool` type in the lexer
- Added support for the `bool` type in the parser
- Fixed an inconsistency in token management during parser execution
- Fixed a bug in the lexer for `string` tokens:
  - Tokens of type `string` and `symbol` had a bug that skipped capturing the next token. The issue has been resolved, and tests have been added to cover this case