### PR TITLE
Nil type

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -73,6 +73,9 @@ func (l *Lexer) NextToken() Token {
 		} else if isValidBool(tok.Literal) {
 			tok.Type = Bool
 			return tok
+		} else if isValidNil(tok.Literal) {
+			tok.Type = Void
+			return tok
 		} else if isValidSymbol(tok.Literal) {
 			tok.Type = Symbol
 			return tok
@@ -98,6 +101,10 @@ func (l *Lexer) readExpr() string {
 func validateRegex(expr string, regex string) bool {
 	re := regexp.MustCompile(regex)
 	return re.MatchString(expr)
+}
+
+func isValidNil(expr string) bool {
+	return validateRegex(expr, `^(nil)$`)
 }
 
 func isValidString(expr string) bool {

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -220,3 +220,24 @@ func TestValidateString(t *testing.T) {
 	result := isValidSymbol(expr)
 	assert.False(t, result)
 }
+
+func TestValidateNilStatement(t *testing.T) {
+	input := `(1 nil)`
+	tests := []struct {
+		expectedType    TokenType
+		expectedLiteral string
+	}{
+		{LParen, "("},
+		{Int, `1`},
+		{Void, `nil`},
+		{RParen, ")"},
+	}
+
+	l := NewLexer(input)
+	for _, tt := range tests {
+		tok := l.NextToken()
+
+		assert.Equal(t, tt.expectedType, tok.Type, fmt.Sprintf("Token literal: %q", tok.Literal))
+		assert.Equal(t, tt.expectedLiteral, tok.Literal)
+	}
+}

--- a/lexer/token.go
+++ b/lexer/token.go
@@ -13,6 +13,7 @@ const (
 	Int
 	Float
 	Bool
+	Void
 	EOF
 )
 

--- a/parser/ast/nil.go
+++ b/parser/ast/nil.go
@@ -1,0 +1,25 @@
+package ast
+
+import (
+	lx "github.com/tamercuba/golisp/lexer"
+)
+
+type VoidNode struct {
+	token lx.Token
+}
+
+func NewVoidNode(token lx.Token) *VoidNode {
+	return &VoidNode{token}
+}
+
+func (v *VoidNode) GetToken() lx.Token {
+	return v.token
+}
+
+func (v VoidNode) String() string {
+	return "nil"
+}
+
+func (v *VoidNode) GetValue() any {
+	return nil
+}

--- a/parser/ast/nodes_test.go
+++ b/parser/ast/nodes_test.go
@@ -100,3 +100,14 @@ func TestBooleanDeclaration(t *testing.T) {
 	assert.Equal(t, true, b.GetValue())
 	assert.Equal(t, "true", b.GetToken().Literal)
 }
+
+func TestNilNode(t *testing.T) {
+	var tok lx.Token
+	tok.Literal = "nil"
+	tok.Type = lx.Void
+	n := NewVoidNode(tok)
+
+	assert.Equal(t, "nil", fmt.Sprintf("%v", n))
+	assert.Nil(t, n.GetValue())
+	assert.Equal(t, "nil", n.GetToken().Literal)
+}

--- a/parser/let.go
+++ b/parser/let.go
@@ -34,6 +34,8 @@ func (p *Parser) parseLet() *ast.LetDeclaration {
 		bindingValue = p.parseString()
 	case lx.Bool:
 		bindingValue = p.parseBoolean()
+	case lx.Void:
+		bindingValue = p.parseVoid()
 	default:
 		panic(fmt.Sprintf("%q Type Error. %q isnt a valid binding value", p.peekToken.Pos, p.peekToken))
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -52,6 +52,9 @@ func ParseProgram(l *lx.Lexer) (*ast.Program, error) {
 		case lx.Bool:
 			n := p.parseBoolean()
 			program.ListStatements = append(program.ListStatements, n)
+		case lx.Void:
+			n := p.parseVoid()
+			program.ListStatements = append(program.ListStatements, n)
 		default:
 			panic("INVALID SYNTAX")
 		}
@@ -93,6 +96,8 @@ func (p *Parser) parseList() ast.Node {
 			list.Append(p.parseSymbol())
 		case lx.Bool:
 			list.Append(p.parseBoolean())
+		case lx.Void:
+			list.Append(p.parseVoid())
 		case lx.EOF:
 			panic(fmt.Sprintf("%v( not closed, expect ).", list.GetToken().Pos))
 		default:
@@ -121,6 +126,12 @@ func (p *Parser) parseFloat() *ast.FloatLiteral {
 
 func (p *Parser) parseString() *ast.StringLiteral {
 	result := ast.NewStringLiteral(p.curToken)
+	p.nextToken()
+	return result
+}
+
+func (p *Parser) parseVoid() *ast.VoidNode {
+	result := ast.NewVoidNode(p.curToken)
 	p.nextToken()
 	return result
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -343,3 +343,51 @@ func TestUnbalancedList(t *testing.T) {
 	}()
 	ParseProgram(l)
 }
+
+func TestAssignmentWithNilValue(t *testing.T) {
+	input := `(let x nil)`
+	l := lexer.NewLexer(input)
+	r, err := ParseProgram(l)
+
+	assert.Equal(t, 1, len(r.ListStatements))
+	s := r.ListStatements[0]
+
+	assert.Nil(t, err)
+	assert.IsType(t, &ast.LetDeclaration{}, s)
+	assert.Equal(t, "let", s.GetToken().Literal)
+
+	switch v := s.(type) {
+	case *ast.LetDeclaration:
+		assert.Equal(t, "x", v.Name.String())
+		assert.Nil(t, v.Value.GetValue())
+		assert.Equal(t, "(let x nil)", fmt.Sprintf("%v", v))
+	default:
+		assert.Fail(t, fmt.Sprintf("Invalid type: %+v", v))
+	}
+}
+
+func TestNil(t *testing.T) {
+	input := `nil`
+	l := lexer.NewLexer(input)
+	r, err := ParseProgram(l)
+
+	assert.Equal(t, 1, len(r.ListStatements))
+	s := r.ListStatements[0]
+
+	assert.Nil(t, err)
+	assert.IsType(t, &ast.VoidNode{}, s)
+	assert.Nil(t, s.GetValue())
+	assert.Equal(t, "nil", s.String())
+}
+
+func TestListWithNilValue(t *testing.T) {
+	input := `(1 nil 2 nil)`
+	l := lexer.NewLexer(input)
+	r, err := ParseProgram(l)
+
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(r.ListStatements))
+	s := r.ListStatements[0]
+
+	assert.IsType(t, &ast.ListExpression{}, s)
+}


### PR DESCRIPTION
## 🔨 Describe your changes

- Added support for the `nil` type in the interpreter.
- Updated the lexer to recognize `nil` as a valid token.
- Enhanced the parser to handle `nil` tokens and include them as valid nodes in the AST.
- Added tests to validate `nil` handling in various scenarios, including:
  - Lists containing `nil` values.
  - Expressions where `nil` is used as a standalone value.
