### PR TITLE
 lambda support

### DIFF
--- a/parser/ast/lambda.go
+++ b/parser/ast/lambda.go
@@ -1,0 +1,35 @@
+package ast
+
+import (
+	"fmt"
+	"strings"
+
+	lx "github.com/tamercuba/golisp/lexer"
+)
+
+type LambdaNode struct {
+	token lx.Token
+	Args  []Symbol
+	Body  Node
+}
+
+func NewLambdaNode(token lx.Token, Args []Symbol, Body Node) *LambdaNode {
+	return &LambdaNode{token, Args, Body}
+}
+
+func (l *LambdaNode) GetToken() lx.Token {
+	return l.token
+}
+
+func (l LambdaNode) String() string {
+	argsStrings := []string{}
+	for _, argName := range l.Args {
+		argsStrings = append(argsStrings, argName.String())
+	}
+	argsResult := fmt.Sprintf("%v", strings.Join(argsStrings, " "))
+	return fmt.Sprintf("(lambda (%v) (%v))", argsResult, l.Body.String())
+}
+
+func (l *LambdaNode) GetValue() any {
+	return nil
+}

--- a/parser/ast/nodes_test.go
+++ b/parser/ast/nodes_test.go
@@ -111,3 +111,18 @@ func TestNilNode(t *testing.T) {
 	assert.Nil(t, n.GetValue())
 	assert.Equal(t, "nil", n.GetToken().Literal)
 }
+
+func TestLambdaNode(t *testing.T) {
+	var tok lx.Token
+	tok.Literal = "lambda"
+	tok.Type = lx.Symbol
+	args := []Symbol{}
+
+	var lTok lx.Token
+	tok.Literal = "("
+	tok.Type = lx.LParen
+	body := NewListExpression(lTok)
+	l := NewLambdaNode(tok, args, body)
+
+	assert.Equal(t, "(lambda () ())", fmt.Sprintf("%v", l))
+}

--- a/parser/defun.go
+++ b/parser/defun.go
@@ -14,34 +14,46 @@ func (p *Parser) parseDefun() *ast.FunctionDeclaration {
 	if p.peekToken.Type != lx.Symbol {
 		panic(fmt.Sprintf("%v Type Error. %v isnt a valid function name", p.peekToken.Pos, p.peekToken))
 	}
-
 	p.nextToken()
 	funcName := ast.NewSymbol(p.curToken)
-
-	//        c p
-	// (defun x (y) (+ 1 y))
-	if p.peekToken.Type != lx.LParen {
-		panic(fmt.Sprintf("%v Type Error. Function args should be a List, not %v", p.peekToken.Pos, p.peekToken))
-	}
-
 	p.nextToken()
-	funcArgs := p.parseDefunArgs()
 
-	//              cp
-	// (defun x (y) (+ 1 y))
+	funcArgs := p.getFunctionArgs()
+	body := p.getFunctionBody()
+	return ast.NewFunctionDeclaration(firstToken, funcName, funcArgs, body)
+}
+
+func (p *Parser) parseLambda() *ast.LambdaNode {
+	//  c      p
+	// (lambda (x y) (+ x y))
+	firstToken := p.curToken
+	p.nextToken()
+	funcArgs := p.getFunctionArgs()
+	body := p.getFunctionBody()
+
+	return ast.NewLambdaNode(firstToken, funcArgs, body)
+}
+
+func (p *Parser) getFunctionBody() ast.Node {
+	//               cp
+	// (lambda (x y) (+ x y))
 	if p.peekToken.Type != lx.LParen {
 		panic(fmt.Sprintf("%v Type Error. Function body should be a list, not %v", p.peekToken.Pos, p.peekToken))
 	}
 	p.nextToken()
 	body := p.parseList()
-
-	return ast.NewFunctionDeclaration(firstToken, funcName, funcArgs, body)
+	return body
 }
 
-func (p *Parser) parseDefunArgs() []ast.Symbol {
+func (p *Parser) getFunctionArgs() []ast.Symbol {
 	//          cp
 	// (defun x (y) (+ 1 y))
+	if p.curToken.Type != lx.LParen {
+		panic(fmt.Sprintf("%v Type Error. Function args should be a List, not %v", p.peekToken.Pos, p.peekToken))
+	}
+
 	p.nextToken()
+
 	//           c p
 	// (defun x (y z) (+ z y))
 	args := []ast.Symbol{}
@@ -54,7 +66,7 @@ func (p *Parser) parseDefunArgs() []ast.Symbol {
 		case lx.RParen:
 			return args
 		default:
-			panic(fmt.Sprintf("%v Invalid Syntax. %v Should be a valid function argument or )", p.curToken.Pos, p.curToken))
+			panic(fmt.Sprintf("%+v Invalid Syntax. %+v Should be a valid function argument or )", p.curToken.Pos, p.curToken))
 		}
 	}
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -151,6 +151,9 @@ func (p *Parser) parseNextSymbol() ast.Node {
 		case "let":
 			p.nextToken()
 			return p.parseLet()
+		case "lambda":
+			p.nextToken()
+			return p.parseLambda()
 		default:
 			// Nothing special
 			return nil


### PR DESCRIPTION
## 🔨 Describe your changes

- Added support for the `lambda` declaration in the interpreter.
- Enhanced the parser to handle `lambda` symbols and include them as valid nodes in the AST.
- Added tests to validate `lambda` handling in various scenarios
